### PR TITLE
Adds item overlays to sec & toolbelts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -12,6 +12,7 @@
 	drop_sound = 'sound/items/drop/toolbelt.ogg'
 	pickup_sound = 'sound/items/pickup/toolbelt.ogg'
 	sprite_sheets = list(SPECIES_TESHARI = 'icons/inventory/belt/mob_teshari.dmi')
+	var/content_overlays = FALSE //VOREStation edit - If this is true, the belt will gain overlays based on what it's holding
 
 	var/show_above_suit = 0
 
@@ -26,15 +27,28 @@
 	update_icon()
 
 //Some belts have sprites to show icons
+//VOREStation edit begins
 /obj/item/weapon/storage/belt/make_worn_icon(var/body_type,var/slot_name,var/inhands,var/default_icon,var/default_layer = 0,var/icon/clip_mask = null)
 	var/image/standing = ..()
 	if(!inhands && contents.len)
 		for(var/obj/item/i in contents)
 			var/i_state = i.item_state
 			if(!i_state) i_state = i.icon_state
-			standing.add_overlay(image(icon = INV_BELT_DEF_ICON, icon_state = i_state))
+			standing.add_overlay(image(icon = 'icons/vore/belt_onmob.dmi', icon_state = i_state))
 	return standing
 
+/obj/item/weapon/storage/belt/update_icon()	
+	if(content_overlays == TRUE)
+		cut_overlays()
+		for(var/obj/item/i in contents)
+			var/i_state = i.item_state
+			if(!i_state) i_state = i.icon_state
+			add_overlay(image(icon = 'icons/vore/belt_overlay.dmi', icon_state = i_state))
+	if (ismob(src.loc))
+		var/mob/M = src.loc
+		M.update_inv_belt()
+
+//VOREStation edit ends
 /obj/item/weapon/storage/update_icon()
 	if (ismob(src.loc))
 		var/mob/M = src.loc
@@ -44,6 +58,7 @@
 	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "Can hold various tools."
 	icon_state = "utility"
+	var/content_overlays = TRUE //VOREStation edit
 	can_hold = list(
 		///obj/item/weapon/combitool,
 		/obj/item/weapon/tool/crowbar,
@@ -131,6 +146,7 @@
 	icon_state = "utility_holding"
 	storage_slots = 14 //twice the amount as a normal belt
 	max_storage_space = ITEMSIZE_COST_NORMAL * 14
+	var/content_overlays = FALSE //VOREStation edit - something something bluespace pockets, why would they be visible from the outside?
 	can_hold = list(
 	/obj/item/weapon/tool/crowbar,
 		/obj/item/weapon/tool/screwdriver,
@@ -221,6 +237,7 @@
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "security"
 	max_w_class = ITEMSIZE_NORMAL
+	var/content_overlays = TRUE //there's some sprites for this, mostly of batons, flashbangs & cuffs.
 	can_hold = list(
 		/obj/item/weapon/grenade,
 		/obj/item/weapon/reagent_containers/spray/pepper,


### PR DESCRIPTION
Or atleast, in theory it will.
Current issues with this are some overlays not displaying correctly, and the fact that the code I've got for this is incredibly jank. Or at least, it _looks_ it.

The biggest problem is that in testing the items put in to adjust the icon in the players inventory call the item_state name, but it doesn't seem to _recognise_ those in the DMI's. So red wirecutters will display on the belt's sprite (but with white handles, for whatever reason?), but yellow & blue simply don't show, despite it trying to apply "cutters_yellow" or "cutters_blue" & the corresponding sprites being named as such. Similar issue with screwdrivers and any other subtype, so the basic crowbar displays, but not the red one, or the jaws of life, etc etc.

I'd appreciate a measure of _help_ with this, given it would be nice to have & opens up plenty of further opportunities for overlaying on other belts as well.

![image](https://user-images.githubusercontent.com/24844135/158700299-ae326f69-83d0-4e5f-94d4-83e00b536d2b.png)
