### PR TITLE
CE & Detective belts tweak

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -116,6 +116,40 @@
 	desc = "Holds tools, looks snazzy."
 	icon_state = "utilitybelt_ce"
 	item_state = "utility_ce"
+	storage_slots = 8	//If they get better everything-else, why not the belt too?
+		can_hold = list(
+		/obj/item/weapon/rcd,	//They've given one from the get-go, it's hard to imagine they wouldn't be given something that can store it neater than a bag
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/weapon/tool/screwdriver,
+		/obj/item/weapon/weldingtool,
+		/obj/item/weapon/tool/wirecutters,
+		/obj/item/weapon/tool/wrench,
+		/obj/item/device/multitool,
+		/obj/item/device/flashlight,
+		/obj/item/weapon/cell/device,
+		/obj/item/stack/cable_coil,
+		/obj/item/device/t_scanner,
+		/obj/item/device/analyzer,
+		/obj/item/clothing/glasses,
+		/obj/item/clothing/gloves,
+		/obj/item/device/pda,
+		/obj/item/device/megaphone,
+		/obj/item/taperoll,
+		/obj/item/device/radio/headset,
+		/obj/item/device/robotanalyzer,
+		/obj/item/weapon/material/minihoe,
+		/obj/item/weapon/material/knife/machete/hatchet,
+		/obj/item/device/analyzer/plant_analyzer,
+		/obj/item/weapon/extinguisher/mini,
+		/obj/item/weapon/tape_roll,
+		/obj/item/device/integrated_electronics/wirer,
+		/obj/item/device/integrated_electronics/debugger,
+		/obj/item/weapon/shovel/spade,
+		/obj/item/stack/nanopaste,
+		/obj/item/device/geiger,
+		/obj/item/areaeditor/blueprints,	//It's a bunch of paper that could prolly be rolled up & slipped into the belt, not to mention CE only, see the RCD's thing above
+		/obj/item/wire_reader	//As above
+		)
 
 /obj/item/weapon/storage/belt/utility/chief/full
 	starts_with = list(
@@ -296,8 +330,9 @@
 		/obj/item/device/flash,
 		/obj/item/weapon/flame/lighter,
 		/obj/item/weapon/reagent_containers/food/snacks/donut/,
-		/obj/item/ammo_magazine,
-		/obj/item/weapon/gun/projectile/colt/detective,
+		///obj/item/ammo_magazine,	//Detectives don't get projectile weapons as standard here
+		///obj/item/weapon/gun/projectile/colt/detective,	//Detectives don't get projectile weapons as standard here
+		/obj/item/weapon/gun/energy/stunrevolver/detective,	//In keeping with the same vein as above, they can store their special one
 		/obj/item/device/holowarrant
 		)
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -117,7 +117,7 @@
 	icon_state = "utilitybelt_ce"
 	item_state = "utility_ce"
 	storage_slots = 8	//If they get better everything-else, why not the belt too?
-		can_hold = list(
+	can_hold = list(
 		/obj/item/weapon/rcd,	//They've given one from the get-go, it's hard to imagine they wouldn't be given something that can store it neater than a bag
 		/obj/item/weapon/tool/crowbar,
 		/obj/item/weapon/tool/screwdriver,


### PR DESCRIPTION
Gives the CE a belt that has a single extra slot on it, along with allowing some of the kit they get as standard to be put in it. 
Doesn't go balls-to-the-walls OTT with what's able to be put in it like the belts of holding do.

Additionally, the forensics belt had the ability to hold the old detective 1911 commented out & replaced with the new stun revolver they get.